### PR TITLE
docs (changes to documentation): add clarification on key name for graphqlReducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ import thunk from 'redux-thunk';
 
 const store = createStore(
   combineReducers({
-    iguazuGraphQL: graphqlReducer,  
+    iguazuGraphQL: graphqlReducer,
   }),
   applyMiddleware(thunk)
 );
-// The graphqlReducer key name must be iguazuGraphQL 
+// The graphqlReducer key name must be iguazuGraphQL
 
 addGraphQLEndpoints([
   {

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ import thunk from 'redux-thunk';
 
 const store = createStore(
   combineReducers({
-    iguazuGraphQL: graphqlReducer,
+    iguazuGraphQL: graphqlReducer,  
   }),
   applyMiddleware(thunk)
 );
+// The graphqlReducer key name must be iguazuGraphQL 
 
 addGraphQLEndpoints([
   {


### PR DESCRIPTION
docs (changes to documentation): add clarification on key name for graphqlReducer

Added a single line code comment to the README.md clarifying that The graphqlReducer key name must be iguazuGraphQL

Related  #3;
