### PR TITLE
chore(deps): update fetch-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4798,9 +4798,9 @@
       }
     },
     "fetch-mock": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.0.1.tgz",
-      "integrity": "sha512-omxXRmQJDWLbOpA907JMFNdjLkHAfOGIqcyS/1dJ/0EEyi19iIyYjT2nveT+4Nwmuh/HgRSsNwRl+HP690ZdGQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.3.2.tgz",
+      "integrity": "sha512-RUdLbhIBTvECX20I8htNhmLRrCplCiOP62srst8UQsSV0m8taJe31PBsQybL7OIq5fEf6tnqVGvQ62ZnZ4IFfQ==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -4813,9 +4813,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.7.tgz",
-          "integrity": "sha512-qaPVGw30J1wQ0GR3GvoPqlGf9GZfKKF4kFC7kiHlcsPTqH3txrs9crCp3ZiMAXuSenhz89Jnl4GZs/67S5VOSg==",
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint": "^6.5.0",
     "eslint-config-amex": "^11.1.0",
     "fetch-everywhere": "^1.0.5",
-    "fetch-mock": "^8.0.0",
+    "fetch-mock": "^8.3.2",
     "husky": "^3.0.9",
     "jest": "^24.1.0",
     "lockfile-lint": "^3.0.8",


### PR DESCRIPTION
This fixes an issue with an earlier version of fetch-mock that was causing failures within Travis.