### PR TITLE
feat(selectors): export getStateOfQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ const store = createStore(
 configureIguazuGraphQL({ getToState: (state) => state.deep.deeper.deepEnough });
 ```
 
+### Selectors
+
+#### getStateOfQuery
+
+Retrieve the existing result of a query from Redux state.
+
+```js
+const queryState = getStateOfQuery({ endpointName, query, variables })(getState);
+if (queryState) {
+  // do something with ...
+  queryState.toJS();
+}
+```
+
 ## 🏆 Contributing
 
 We welcome Your interest in the American Express Open Source Community on Github.

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -17,6 +17,7 @@
 import 'fetch-everywhere';
 
 import graphqlReducer from '../src/duck/reducer';
+import { getStateOfQuery } from '../src/duck/selectors';
 import { configureIguazuGraphQL } from '../src/config';
 // import gql from '../src/gql';
 import addGraphQLEndpoints from '../src/addGraphQLEndpoints';
@@ -27,6 +28,7 @@ import * as index from '../src';
 
 describe('index', () => {
   it('exports the redux reducer as graphqlReducer', () => expect(index.graphqlReducer).toBe(graphqlReducer));
+  it('exports query selector getStateOfQuery', () => expect(index.getStateOfQuery).toBe(getStateOfQuery));
   it('exports configureIguazuGraphQL', () => expect(index.configureIguazuGraphQL).toBe(configureIguazuGraphQL));
   // it('exports gql');
   it('exports addGraphQLEndpoints', () => expect(index.addGraphQLEndpoints).toBe(addGraphQLEndpoints));

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@
  */
 
 import graphqlReducer from './duck/reducer';
+import { getStateOfQuery } from './duck/selectors';
 import { configureIguazuGraphQL } from './config';
 import addGraphQLEndpoints from './addGraphQLEndpoints';
 import queryGraphQLData from './useGraphQLData/query';
@@ -24,6 +25,7 @@ import mutateGraphQLData from './useGraphQLData/mutate';
 export {
   configureIguazuGraphQL,
   graphqlReducer,
+  getStateOfQuery,
   addGraphQLEndpoints,
   queryGraphQLData,
   clearQueryData,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR extends exports for selectors to ease access of existing query results from Redux without making a request.

## Description
<!--- Describe your changes in detail -->
* Export existing selectors (`getStateOfQuery`)
* Update README accordingly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently consumers of this library can only access query results indirectly by using `loadDataAsProps` inside `connectAsync`. 
There is no way to read data directly from Redux for a given set of `{ endpointName, query, variables }`, but data may be read from selectors outside of a component's lifecycle.

This follow the `iguazu-rpc` pattern of `getProcedureResult` to retrieve the result of a procedure without making a request.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No other parts are affected.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Iguazu-Graphql?
<!--- Please describe how your changes impacts developers using Iguazu-Graphql. -->
Developers can access query results from Redux outside of `loadDataAsProps` or `connectAsync` lifecycle.